### PR TITLE
feat: support preload tiflash replicas

### DIFF
--- a/ddl/2-status-ddl.sql
+++ b/ddl/2-status-ddl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE status
+(
+    status_name  VARCHAR(100) NOT NULL PRIMARY KEY,
+    status_type  ENUM('number', 'string', 'object', 'array', 'date') NOT NULL,
+    status_value JSON NULL
+);
+
+INSERT INTO status (status_name, status_type, status_value)
+VALUES ('last_preload_at', 'date', '"1970-01-01"');

--- a/src/app/api/v1/documents/preload/route.ts
+++ b/src/app/api/v1/documents/preload/route.ts
@@ -31,7 +31,7 @@ export async function POST (req: NextRequest) {
   }
 }
 
-export async function preloadTiFlashReplicas(tables: string[]){
+async function preloadTiFlashReplicas(tables: string[]){
   for (const table of tables) {
     const duration = await measure(async () => {
       return await sql`SELECT /*+ READ_FROM_STORAGE(TIFLASH[${sql.ref(table)}]) */ COUNT(*) FROM ${sql.ref(table)};`.execute(db);
@@ -40,7 +40,7 @@ export async function preloadTiFlashReplicas(tables: string[]){
   }
 }
 
-export async function measure(action: () => Promise<any>){
+async function measure(action: () => Promise<any>){
   const start = new Date();
   await action();
   const end = new Date();

--- a/src/app/api/v1/documents/preload/route.ts
+++ b/src/app/api/v1/documents/preload/route.ts
@@ -1,0 +1,50 @@
+import {type NextRequest, NextResponse} from 'next/server';
+import {sql} from "kysely";
+import database from "@/core/db";
+import {db} from "@/core/db/db";
+
+export async function POST (req: NextRequest) {
+  try {
+    const success = await database.status.compareAndSwap<Date>('last_preload_at', new Date(), (oldDate, newDate) => {
+      // The interval of preloading should more than 10 minutes.
+      return (newDate.getTime() - oldDate.getTime()) > 10 * 60 * 1000;
+    }, async () => {
+      console.log('Preloading TiFlash replicas ...')
+      await preloadTiFlashReplicas(['document', 'document_index_chunk']);
+      return;
+    });
+
+    if (success) {
+      return NextResponse.json({
+        message: 'success'
+      });
+    } else {
+      return NextResponse.json({
+        message: 'skipped'
+      });
+    }
+  } catch (e) {
+    console.error('Failed to preload TiFlash replicas:', e);
+    return NextResponse.json({
+      message: 'error'
+    });
+  }
+}
+
+export async function preloadTiFlashReplicas(tables: string[]){
+  for (const table of tables) {
+    const duration = await measure(async () => {
+      return await sql`SELECT /*+ READ_FROM_STORAGE(TIFLASH[${sql.ref(table)}]) */ COUNT(*) FROM ${sql.ref(table)};`.execute(db);
+    });
+    console.log(`Preload table <${table}> in ${duration} ms`);
+  }
+}
+
+export async function measure(action: () => Promise<any>){
+  const start = new Date();
+  await action();
+  const end = new Date();
+  return end.getTime() - start.getTime();
+}
+
+export const dynamic = 'force-dynamic';

--- a/src/core/db/index.ts
+++ b/src/core/db/index.ts
@@ -4,6 +4,7 @@ import { documentDb, type DocumentDb } from '@/core/db/document';
 import { importSourceDb, type ImportSourceDb } from '@/core/db/importSource';
 import { taskDb, type TaskDb } from '@/core/db/task';
 import {OptionDb, optionDb} from "@/core/db/options";
+import {statusDb, StatusDb} from "@/core/db/status";
 
 export interface Database {
   document: DocumentDb;
@@ -12,6 +13,7 @@ export interface Database {
   task: TaskDb;
   importSource: ImportSourceDb,
   chat: ChatDb,
+  status: StatusDb;
 }
 
 const database = {
@@ -21,6 +23,7 @@ const database = {
   task: taskDb,
   importSource: importSourceDb,
   chat: chatDb,
+  status: statusDb
 } satisfies Database;
 
 export default database;

--- a/src/core/db/schema.d.ts
+++ b/src/core/db/schema.d.ts
@@ -144,6 +144,12 @@ export interface Option {
   option_value: Json | null;
 }
 
+export interface Status {
+  status_name: string;
+  status_type: "array" | "number" | "object" | "string" | "date";
+  status_value: Json | null;
+}
+
 export interface VDocumentIndexStatus {
   document_id: string | null;
   index_name: string | null;
@@ -166,5 +172,6 @@ export interface DB {
   index_query: IndexQuery;
   index_query_result: IndexQueryResult;
   option: Option;
+  status: Status;
   v_document_index_status: VDocumentIndexStatus;
 }

--- a/src/core/db/status.ts
+++ b/src/core/db/status.ts
@@ -1,0 +1,79 @@
+import { db } from '@/core/db/db';
+import type {DB, Json, JsonValue} from '@/core/db/schema';
+import {Selectable, sql, UpdateResult} from 'kysely';
+
+export interface StatusDb {
+
+  findByName(name: string): Promise<Selectable<DB['status']> | undefined>;
+
+  updateByName(name: string, value: any): Promise<UpdateResult[]>;
+
+  compareAndSwap<V>(name: string, newValue: V, needUpdate: (oldVal: V, newVal: V) => boolean, action: () => Promise<void>): Promise<boolean>;
+
+}
+
+export const statusDb: StatusDb = {
+
+  async findByName(name: string) {
+    return await db.selectFrom('status')
+      .selectAll()
+      .where('status_name', '=', eb => eb.val(name))
+      .executeTakeFirst();
+  },
+
+  async updateByName(name: string, value: any) {
+    return await db.updateTable('status')
+        .set({
+          status_value: JSON.stringify(value)
+        })
+        .where('status_name', '=', name)
+        .execute();
+  },
+
+  async compareAndSwap<V>(name: string, newValue: V, needUpdate: (oldVal: V, newVal: V) => boolean, action: () => Promise<void>): Promise<boolean> {
+    return await db.transaction().execute(async txn => {
+      let oldStatus;
+      try {
+        oldStatus = await txn.selectFrom('status')
+          .selectAll()
+          .where('status_name', '=', name)
+          .forUpdate()
+          .noWait()
+          .executeTakeFirstOrThrow();
+      } catch (e: any) {
+        // Skip if the record is locked.
+        if (e?.code === 'ER_LOCK_NOWAIT') {
+          return false;
+        }
+        throw e;
+      }
+
+      // Handle date type.
+      let oldValue = oldStatus.status_value as any;
+      if (oldStatus.status_type == 'date') {
+        try {
+          oldValue = new Date(oldStatus.status_value as string);
+        } catch (e) {
+          console.warn('Invalid date format in status value:', oldStatus.status_value);
+          return false;
+        }
+      }
+
+      // Skip if no need to update.
+      if (!needUpdate(oldValue, newValue)) {
+        return false;
+      }
+
+      await action();
+
+      await txn.updateTable('status')
+        .set({
+          status_value: JSON.stringify(newValue)
+        })
+        .where('status_name', '=', name)
+        .execute();
+      return true;
+    });
+  }
+
+};


### PR DESCRIPTION
TiDB Serverless uses S3 as the underlying storage for TiFlash Replica, and data may need to be loaded from S3 to the local disk during the initial query. This PR has added an API `/api/v1/documents/preload` that triggers data preloading.

The preload SQL as follows:

```sql
SELECT /*+ READ_FROM_STORAGE(TIFLASH[`document`]) */ 1 FROM `document` ORDER BY `source_uri` LIMIT 1;
```

```sql
SELECT /*+ READ_FROM_STORAGE(TIFLASH[`document_index_chunk`]) */ 1 FROM `document_index_chunk` ORDER BY `embedding` LIMIT 1;
```