### PR TITLE
feat: html loader support metadata extraction from URL

### DIFF
--- a/extensions/html-loader/HtmlLoader.ts
+++ b/extensions/html-loader/HtmlLoader.ts
@@ -1,7 +1,7 @@
 import { rag } from '@/core/interface';
 import { md5 } from '@/lib/digest';
 import { createUrlMatcher } from '@/lib/url-matcher';
-import { type HtmlSelectorItemType } from '@/lib/zod-extensions/types/html-selector-array';
+import {HtmlSelectorItemType} from "@/lib/zod-extensions/types/html-selector-array";
 import type { Element, Root } from 'hast';
 import { select, selectAll } from 'hast-util-select';
 import { toText } from 'hast-util-to-text';

--- a/extensions/html-loader/meta.ts
+++ b/extensions/html-loader/meta.ts
@@ -1,6 +1,6 @@
-import { rag } from '@/core/interface';
+import {rag} from '@/core/interface';
 import {htmlSelectorArray, type HtmlSelectorItemType} from '@/lib/zod-extensions/types/html-selector-array';
-import { z } from 'zod';
+import {z} from 'zod';
 import Readme from './readme.mdx';
 import BaseMeta = rag.BaseMeta;
 
@@ -109,11 +109,11 @@ export const htmlLoaderOptionsSchema = z.object({
   /**
    * The configuration for content extraction.
    */
-  contentExtraction: contentExtractionSchema.array(),
+  contentExtraction: contentExtractionSchema.array().optional(),
   /**
    * The configuration for metadata extraction.
    */
-  metadataExtraction: metadataExtractionSchema.array(),
+  metadataExtraction: metadataExtractionSchema.array().optional(),
 });
 
 export type HtmlLoaderOptions = z.infer<typeof htmlLoaderOptionsSchema>;

--- a/extensions/html-loader/meta.ts
+++ b/extensions/html-loader/meta.ts
@@ -1,31 +1,130 @@
 import { rag } from '@/core/interface';
-import { htmlSelectorArray } from '@/lib/zod-extensions/types/html-selector-array';
+import {htmlSelectorArray, type HtmlSelectorItemType} from '@/lib/zod-extensions/types/html-selector-array';
 import { z } from 'zod';
 import Readme from './readme.mdx';
 import BaseMeta = rag.BaseMeta;
 
-const contentExtractionConfigSchema = z.object({
+export const DEFAULT_TEXT_SELECTORS: HtmlSelectorItemType[] = [
+  { selector: 'body', all: false, type: 'dom-text' }
+]
+
+export const DEFAULT_EXCLUDE_SELECTORS: HtmlSelectorItemType[] = [
+  { selector: 'script', all: true }
+];
+
+/**
+ * The rule to extract content from the HTML document.
+ */
+export const contentExtractionSchema = z.object({
+  // TODO: rename to urlPattern is better
   url: z.string(),
-  excludeSelectors: htmlSelectorArray().default([
-    { selector: 'script', type: 'dom-text', all: true },
-  ]),
+  excludeSelectors: htmlSelectorArray().default(DEFAULT_EXCLUDE_SELECTORS),
   selectors: htmlSelectorArray(),
-}).array();
-
-export interface HtmlLoaderOptions {
-  // rehypeParse?: RehypeParseOptions;
-  contentExtraction?: z.infer<typeof contentExtractionConfigSchema>;
-}
-
-export const optionsSchema = z.object({
-  // rehypeParse: z.object({}).passthrough().optional(),
-  contentExtraction: contentExtractionConfigSchema.optional(),
 });
 
+export type ContentExtraction = z.infer<typeof contentExtractionSchema>;
+
+/**
+ * Metadata Extractor Type
+ */
+export enum MetadataExtractorType {
+  URL_METADATA_EXTRACTOR = 'url-metadata-extractor',
+  HTML_METADATA_EXTRACTOR = 'html-metadata-extractor',
+}
+
+export const ExtractedMetadataSchema = z.record(z.string(), z.string().or(z.string().array())).default({});
+
+export type ExtractedMetadata = z.infer<typeof ExtractedMetadataSchema>;
+
+/**
+ * The base executor to extract metadata from the HTML document.
+ */
+export const metadataExtractorSchema = z.object({
+  /**
+   * The type of the extractor.
+   */
+  type: z.nativeEnum(MetadataExtractorType),
+  /**
+   * The default metadata to be extracted.
+   *
+   * The parameter in the pattern can be optional, and the default value will be used if the parameter is not found.
+   */
+  defaultMetadata: z.record(z.string(), z.string().or(z.string().array())).default({}).optional(),
+});
+
+export type MetadataExtractor = z.infer<typeof metadataExtractorSchema>;
+
+/**
+ * The URL Metadata Extractor.
+ */
+export const URLMetadataExtractor = metadataExtractorSchema.extend({
+  type: z.literal(MetadataExtractorType.URL_METADATA_EXTRACTOR),
+  /**
+   *
+   * The pattern to match the metadata in the URL.
+   *
+   * For example, if the url is "https://docs.pingcap.com/zh/tidb/stable/overview", the `extractPattern` field can be:
+   *
+   * ```plain
+   * https://docs.pingcap.com/:language(zh|jp)?/:product(tidb|tidbcloud)/:version(dev|stable|v\d/\d)/(.*)
+   * ```
+   *
+   * So the extracted labels will be:
+   *
+   * ```json
+   * {
+   *  language: "zh",
+   *  product: "tidb",
+   *  version: "stable"
+   * }
+   * ```
+   *
+   * Check {@link https://github.com/pillarjs/path-to-regexp} for more information.
+   */
+  urlMetadataPattern: z.string()
+});
+
+export type URLMetadataExtractor = z.infer<typeof URLMetadataExtractor> & MetadataExtractor;
+
+/**
+ * The extraction to extract metadata from the URL / HTML document.
+ */
+export const metadataExtractionSchema = z.object({
+  /**
+   * `urlPattern` is used to match the URL which the rule should be applied to.
+   */
+  urlPattern: z.string(),
+  /**
+   * The extractors to be used.
+   */
+  extractors: URLMetadataExtractor.array(),
+});
+
+export type MetadataExtraction = z.infer<typeof metadataExtractionSchema>;
+
+/**
+ * The options for the HTML loader.
+ */
+export const htmlLoaderOptionsSchema = z.object({
+  /**
+   * The configuration for content extraction.
+   */
+  contentExtraction: contentExtractionSchema.array(),
+  /**
+   * The configuration for metadata extraction.
+   */
+  metadataExtraction: metadataExtractionSchema.array(),
+});
+
+export type HtmlLoaderOptions = z.infer<typeof htmlLoaderOptionsSchema>;
+
+/**
+ * The metadata of the HTML loader.
+ */
 const htmlLoaderMeta: BaseMeta<HtmlLoaderOptions> = {
   identifier: 'rag.loader.html',
   displayName: 'HTML Loader',
-  optionsSchema,
+  optionsSchema: htmlLoaderOptionsSchema,
   description: Readme,
 };
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "next": "14.2.1",
     "next-auth": "5.0.0-beta.5",
     "openai": "^4.25.0",
+    "path-to-regexp": "^6.2.2",
     "pdfjs-dist": "^4.0.379",
     "react": "^18",
     "react-day-picker": "^8.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       openai:
         specifier: ^4.25.0
         version: 4.25.0
+      path-to-regexp:
+        specifier: ^6.2.2
+        version: 6.2.2
       pdfjs-dist:
         specifier: ^4.0.379
         version: 4.0.379
@@ -11864,6 +11867,10 @@ packages:
     dependencies:
       lru-cache: 10.1.0
       minipass: 7.0.4
+
+  /path-to-regexp@6.2.2:
+    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}

--- a/src/app/api/test/html-loader/route.ts
+++ b/src/app/api/test/html-loader/route.ts
@@ -1,0 +1,64 @@
+import { baseRegistry } from '@/rag-spec/base';
+import { NextResponse } from 'next/server';
+
+const testHTML = `
+<html lang="en">
+<head>
+    <title>title</title>
+</head>
+<body>
+    <main>
+        <div class="ad">ad</div>
+        <h1>heading</h1>
+        <p>paragraph</p>
+    </main>
+    <div class="ad">ad</div>
+</body>    
+</html>
+`;
+
+const testURL = 'https://docs.pingcap.com/tidb/stable/tidb-architecture/subpage';
+
+export async function GET () {
+  let loader = await baseRegistry.create('rag.loader.html', {
+    contentExtraction: [
+      {
+        url: 'docs.pingcap.com/**',
+        selectors: [
+          {
+            selector: 'main',
+            all: true,
+            type: 'dom-text',
+          }
+        ],
+        excludeSelectors: [
+          {
+            selector: '.ad',
+            all: true,
+          }
+        ],
+      },
+    ],
+    metadataExtraction: [
+      {
+        urlPattern: 'docs.pingcap.com/**',
+        extractors: [
+          {
+            type: 'url-metadata-extractor',
+            urlMetadataPattern: '/:language(zh|jp)?/:product(tidb|tidbcloud)/:version(dev|stable|v\\d/\\d)(/.*)',
+            defaultMetadata: {
+              language: 'en',
+              version: 'stable',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = loader.load(Buffer.from(testHTML), testURL);
+
+  return NextResponse.json(result);
+}
+
+export const dynamic = 'force-dynamic';

--- a/src/app/api/v1/tasks/temp_fill_document_metadata/route.ts
+++ b/src/app/api/v1/tasks/temp_fill_document_metadata/route.ts
@@ -1,0 +1,82 @@
+import {getDb} from '@/core/db';
+import {getIndexByNameOrThrow} from "@/core/repositories/index_";
+import {fromFlowReaders} from "@/lib/llamaindex/converters/reader";
+import {executeInSafeDuration} from "@/lib/next/executeInSafeDuration";
+import {defineHandler} from '@/lib/next/handler';
+import {baseRegistry} from '@/rag-spec/base';
+import {getFlow} from '@/rag-spec/createFlow';
+
+export const GET = defineHandler({ auth: 'cronjob' }, async () => {
+  const flow = await getFlow(baseRegistry);
+  const index = await getIndexByNameOrThrow('default');
+  const reader = fromFlowReaders(flow, index.config.reader);
+
+  await executeInSafeDuration(async () => {
+    const documentWithoutMeta = await getDb().selectFrom('llamaindex_document_node')
+      .selectAll()
+      .where((eb) => {
+        return eb(
+          eb.ref('metadata', '->$').key('documentMetadata' as never),
+          'is',
+          eb.val(null),
+        )
+      })
+      .limit(100)
+      .execute();
+
+    console.log(`Found ${documentWithoutMeta.length} documents without metadata.`)
+
+    const documentIds = Array.from(new Set(documentWithoutMeta.map(doc => doc.document_id)));
+    const documents = await getDb()
+      .selectFrom('document')
+      .select('id')
+      .select('content_uri')
+      .select('source_uri')
+      .where('id', 'in', documentIds)
+      .where('mime', '=', 'text/html')
+      .execute();
+
+    console.log(`Found ${documents.length} documents to process.`)
+
+    if (documents.length == 0) {
+      return false;
+    }
+
+    await Promise.all(documents.map(async document => {
+      const docsWithMeta = await reader.loadData({
+        mime: 'text/html',
+        content_uri: document.content_uri,
+        source_uri: document.source_uri,
+      });
+
+      console.log(`Processing document ${document.id}.`)
+
+      for (let docWithMeta of docsWithMeta) {
+        await getDb().updateTable('llamaindex_document_node')
+          .where('document_id', '=', document.id)
+          .set(({ eb }) => ({
+            metadata: eb.fn('JSON_MERGE_PATCH', [
+              eb.ref('metadata'),
+              eb.val(JSON.stringify(docWithMeta.metadata)),
+            ]),
+          }))
+          .execute();
+
+        await getDb().updateTable('llamaindex_document_chunk_node_default')
+          .where('document_id', '=', document.id)
+          .set(({ eb }) => ({
+            metadata: eb.fn('JSON_MERGE_PATCH', [
+              eb.ref('metadata'),
+              eb.val(JSON.stringify(docWithMeta.metadata)),
+            ]),
+          }))
+          .execute();
+      }
+    }));
+
+    return true;
+  }, 60, 0.9);
+})
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;

--- a/src/lib/zod-extensions/types/html-selector-array.ts
+++ b/src/lib/zod-extensions/types/html-selector-array.ts
@@ -1,5 +1,6 @@
-import { addIssueToContext, type ParseInput, type ParseReturnType, undefined, z, ZodType, type ZodTypeDef } from 'zod';
+import { addIssueToContext, type ParseInput, type ParseReturnType, z, ZodType, type ZodTypeDef } from 'zod';
 
+// TODO: rename to ContentExtractionRule is better
 export type HtmlSelectorItemType = {
   type?: 'dom-text' | 'dom-content-attr' | undefined
   selector: string

--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,7 @@
     },
     {
       "schedule": "* * * * *",
-      "path": "/api/v1/tasks/temp_fill_document_name"
+      "path": "/api/v1/tasks/temp_fill_document_metadata"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
part of https://github.com/pingcap/tidb.ai/issues/121

For example:

If there is a document URL as below:

```
https://docs.pingcap.com/tidb/v6.5/character-set-and-collation
```

The reader config:

```json
{
  "reader": {
    "rag.loader.html": {
      "metadataExtraction": [
        {
          "extractors": [
            {
              "defaultMetadata": {
                "language": "en",
                "version": "stable"
              },
              "type": "url-metadata-extractor",
              "urlMetadataPattern": "/:language(zh|ja)?/:product(tidb|tidbcloud|tidb\\-data\\-migration|tidb\\-in\\-kubernetes)/:version(dev|stable|v\\d.\\d)(/.*)"
            }
          ],
          "urlPattern": "docs.pingcap.com/**"
        }
      ]
  }
}
```

The html loader will got the metadata as follows:

```json
{
    "documentMetadata": {
      "language": "en",
      "product": "tidb",
      "version": "v6.5"
    }
}
```