### PR TITLE
feat: support metadata post filter

### DIFF
--- a/ddl/0-initial-schema.sql
+++ b/ddl/0-initial-schema.sql
@@ -222,6 +222,7 @@ CREATE TABLE retrieve_result
     document_id            INT        NOT NULL,
     document_chunk_node_id BINARY(16) NOT NULL,
     document_node_id       BINARY(16) NOT NULL,
+    document_metadata      JSON       NOT NULL,
     chunk_text             TEXT       NOT NULL,
     chunk_metadata         JSON       NOT NULL,
     PRIMARY KEY (id),

--- a/extensions/html-loader/HtmlLoader.ts
+++ b/extensions/html-loader/HtmlLoader.ts
@@ -6,14 +6,14 @@ import type {Element, Root} from 'hast';
 import {select, selectAll} from 'hast-util-select';
 import {toText} from 'hast-util-to-text';
 import {match} from 'path-to-regexp';
-import rehypeParse from 'rehype-parse';
 import {Processor, unified} from 'unified';
 import {remove} from 'unist-util-remove';
+import rehypeParse from 'rehype-parse';
 import htmlLoaderMeta, {
   DEFAULT_EXCLUDE_SELECTORS,
   DEFAULT_TEXT_SELECTORS,
   ExtractedMetadata,
-  HtmlLoaderOptions,
+  type HtmlLoaderOptions,
   MetadataExtractor,
   MetadataExtractorType,
   URLMetadataExtractor
@@ -40,10 +40,8 @@ export default class HtmlLoader extends rag.Loader<HtmlLoaderOptions, {}> {
       content: matchedTexts,
       hash: this.getTextHash(matchedTexts),
       metadata: {
-        documentUrl: url,
-        documentMetadata: {
-          ...metadataFromURL
-        }
+        url: url,
+        ...metadataFromURL
       },
     } satisfies rag.Content<{}>;
   }

--- a/src/app/api/v1/indexes/[name]/retrieve/route.ts
+++ b/src/app/api/v1/indexes/[name]/retrieve/route.ts
@@ -1,15 +1,19 @@
-import { LlamaindexRetrieveService } from '@/core/services/llamaindex/retrieving';
-import { retrieveOptionsSchema } from '@/core/services/retrieving';
+import {getChatEngineConfig} from "@/core/repositories/chat_engine";
 import {getIndexByName} from '@/core/repositories/index_';
-import { defineHandler } from '@/lib/next/handler';
-import { baseRegistry } from '@/rag-spec/base';
-import { getFlow } from '@/rag-spec/createFlow';
-import { notFound } from 'next/navigation';
+import {LlamaindexRetrieveService} from '@/core/services/llamaindex/retrieving';
+import {retrieveOptionsSchema} from '@/core/services/retrieving';
+import {getEmbedding} from "@/lib/llamaindex/converters/embedding";
+import {getLLM} from "@/lib/llamaindex/converters/llm";
+import {defineHandler} from '@/lib/next/handler';
+import {baseRegistry} from '@/rag-spec/base';
+import {getFlow} from '@/rag-spec/createFlow';
+import {serviceContextFromDefaults} from "llamaindex";
+import {notFound} from 'next/navigation';
 import z from 'zod';
 
 export const POST = defineHandler({
   params: z.object({
-    name: z.string()
+    name: z.string(),
   }),
   body: retrieveOptionsSchema,
 }, async ({
@@ -21,17 +25,26 @@ export const POST = defineHandler({
     notFound();
   }
 
+  const [engine, engineOptions] = await getChatEngineConfig(body.engine);
+  const {
+    llm: {
+      provider: llmProvider = 'openai',
+      config: llmConfig = {}
+    } = {},
+  } = engineOptions;
+
   const flow = await getFlow(baseRegistry);
+  const serviceContext = serviceContextFromDefaults({
+    llm: getLLM(flow, llmProvider, llmConfig),
+    embedModel: getEmbedding(flow, index.config.embedding.provider, index.config.embedding.config),
+  });
 
   const retrieveService = new LlamaindexRetrieveService({
-    // TODO: support llm reranker
-    reranker: {
-      provider: 'cohere',
-      options: {},
-    },
+    metadata_filter: engineOptions.metadata_filter,
+    reranker: engineOptions.reranker,
     flow,
     index,
-    serviceContext: {} as any
+    serviceContext
   });
 
   const result = await retrieveService.retrieve(body);

--- a/src/components/semantic-search.tsx
+++ b/src/components/semantic-search.tsx
@@ -60,14 +60,16 @@ function InternalSearchBox () {
 
   const disabled = loading || transitioning;
 
-  const search = (text: string) => {
+  const search = (query: string) => {
     setLoading(true);
     startTransition(() => {
+      // TODO: Allow using different indexes.
       fetch('/api/v1/indexes/default/retrieve', {
         method: 'post',
         body: JSON.stringify({
-          text,
+          query,
           top_k: 5,
+          // TODO: Support metadata filters.
         }),
       }).then(handleErrors)
         .then(res => res.json())

--- a/src/core/db/schema.d.ts
+++ b/src/core/db/schema.d.ts
@@ -1,4 +1,4 @@
-import type { ColumnType } from "kysely";
+import type {ColumnType} from "kysely";
 
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
@@ -165,6 +165,7 @@ export interface RetrieveResult {
   document_chunk_node_id: Buffer;
   document_id: number;
   document_node_id: Buffer;
+  document_metadata: Json;
   id: Generated<number>;
   relevance_score: number;
   retrieve_id: number;

--- a/src/core/services/llamaindex/chating.ts
+++ b/src/core/services/llamaindex/chating.ts
@@ -84,7 +84,6 @@ export class LlamaindexChatService extends AppChatService {
     const retriever = withAsyncIterable<ChatStreamEvent, LlamaindexRetrieverWrapper>((next, fail) => new LlamaindexRetrieverWrapper(retrieveService, {
       search_top_k,
       top_k,
-      filters: {},
       use_cache: false,
     }, serviceContext, {
       onStartSearch: (id, text) => {

--- a/src/core/services/llamaindex/chating.ts
+++ b/src/core/services/llamaindex/chating.ts
@@ -1,17 +1,28 @@
-import { getDb } from '@/core/db';
-import { type Chat, listChatMessages } from '@/core/repositories/chat';
-import type { ChatEngineOptions } from '@/core/repositories/chat_engine';
-import { AppChatService, type ChatOptions, type ChatStreamEvent } from '@/core/services/chating';
-import { LlamaindexRetrieverWrapper, LlamaindexRetrieveService } from '@/core/services/llamaindex/retrieving';
-import { type AppChatStreamSource, AppChatStreamState } from '@/lib/ai/AppChatStream';
-import { uuidToBin } from '@/lib/kysely';
-import { getEmbedding } from '@/lib/llamaindex/converters/embedding';
-import { getLLM } from '@/lib/llamaindex/converters/llm';
-import { ManagedAsyncIterable } from '@/lib/ManagedAsyncIterable';
-import { Liquid } from 'liquidjs';
-import { CompactAndRefine, CondenseQuestionChatEngine, defaultCondenseQuestionPrompt, defaultRefinePrompt, defaultTextQaPrompt, MetadataMode, ResponseSynthesizer, RetrieverQueryEngine, serviceContextFromDefaults, SimplePrompt } from 'llamaindex';
-import { DateTime } from 'luxon';
-import type { UUID } from 'node:crypto';
+import {getDb} from '@/core/db';
+import {type Chat, listChatMessages} from '@/core/repositories/chat';
+import type {ChatEngineOptions} from '@/core/repositories/chat_engine';
+import {AppChatService, type ChatOptions, type ChatStreamEvent} from '@/core/services/chating';
+import {LlamaindexRetrieverWrapper, LlamaindexRetrieveService} from '@/core/services/llamaindex/retrieving';
+import {type AppChatStreamSource, AppChatStreamState} from '@/lib/ai/AppChatStream';
+import {uuidToBin} from '@/lib/kysely';
+import {getEmbedding} from '@/lib/llamaindex/converters/embedding';
+import {getLLM} from '@/lib/llamaindex/converters/llm';
+import {ManagedAsyncIterable} from '@/lib/ManagedAsyncIterable';
+import {Liquid} from 'liquidjs';
+import {
+  CompactAndRefine,
+  CondenseQuestionChatEngine,
+  defaultCondenseQuestionPrompt,
+  defaultRefinePrompt,
+  defaultTextQaPrompt,
+  MetadataMode,
+  ResponseSynthesizer,
+  RetrieverQueryEngine,
+  serviceContextFromDefaults,
+  SimplePrompt
+} from 'llamaindex';
+import {DateTime} from 'luxon';
+import type {UUID} from 'node:crypto';
 
 interface SourceWithNodeId extends AppChatStreamSource {
   id: string;
@@ -44,6 +55,7 @@ export class LlamaindexChatService extends AppChatService {
         search_top_k = 100,
         top_k = 5,
       } = {},
+      metadata_filter,
       reranker,
       prompts: {
         textQa,
@@ -62,6 +74,7 @@ export class LlamaindexChatService extends AppChatService {
     // Build Retriever.
     const retrieveService = new LlamaindexRetrieveService({
       reranker,
+      metadata_filter,
       flow: this.flow,
       index: this.index,
       serviceContext,

--- a/src/lib/llamaindex/converters/metadata-filter.ts
+++ b/src/lib/llamaindex/converters/metadata-filter.ts
@@ -1,0 +1,17 @@
+import type {AppRetrieveServiceOptions} from "@/core/services/retrieving";
+import {MetadataPostFilter} from "@/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter";
+import {ServiceContext} from 'llamaindex';
+
+type MetadataFilterConfig = NonNullable<AppRetrieveServiceOptions['metadata_filter']>['config'];
+
+export function getMetadataFilter (serviceContext: ServiceContext, provider: string, config: MetadataFilterConfig) {
+    switch (provider) {
+      case 'default':
+        return new MetadataPostFilter({
+          serviceContext,
+          ...config
+        });
+      default:
+        throw new Error(`Unknown post filter provider: ${provider}`)
+    }
+}

--- a/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
+++ b/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
@@ -1,4 +1,15 @@
 import {BaseNodePostprocessor, NodeWithScore, ServiceContext, serviceContextFromDefaults} from "llamaindex";
+import z from "zod";
+
+export const metadataFilterSchema = z.object({
+  name: z.string(),
+  // TBD
+  // op: z.string().optional(),
+  value: z.any(),
+  optional: z.boolean().optional()
+});
+
+export type MetadataFieldFilter = z.infer<typeof metadataFilterSchema>;
 
 export interface MetadataField {
   name: string;
@@ -15,8 +26,8 @@ export const defaultMetadataFilterChoicePrompt = ({
   metadataFields: MetadataField[],
   query: string
 }) => {
-  return `Provide the definition of metadata fields and query, please generate 
-the Filter object array in JSON format, the Filter object has two fields: name, value, optional (boolean).
+  return `Provide the definition of metadata fields and query, please generate the necessary Filter 
+object array in JSON format, the Filter object has two fields: 'name' (string), 'value' (any), 'optional' (boolean).
 
 <Metadata Fields Definition>
 ${JSON.stringify(metadataFields, null, 2)}
@@ -26,12 +37,6 @@ ${query}
 
 <Filters>
   `;
-}
-
-export interface MetadataFiledFilter {
-  name: string;
-  value: any;
-  optional: boolean;
 }
 
 export type MetadataFilterChoicePrompt = typeof defaultMetadataFilterChoicePrompt;
@@ -46,14 +51,24 @@ export class MetadataPostFilter implements BaseNodePostprocessor {
    * The definition of metadata fields.
    */
   metadata_fields: MetadataField[] = [];
+  /**
+   * Provide the filters to apply to the search.
+   */
+  filters: MetadataFieldFilter[] | null = null;
 
   constructor(init?: MetadataPostFilterOptions) {
     Object.assign(this, init);
   }
 
   async postprocessNodes(nodes: NodeWithScore[], query: string): Promise<NodeWithScore[]> {
-    const filters = await this.generateFilters(query);
-    console.info('Apply filters:', filters);
+    let filters;
+    if (this.filters) {
+      filters = this.filters;
+      console.info('Apply provided filters:', filters);
+    } else {
+      filters = await this.generateFilters(query);
+      console.info('Apply generated filters:', filters);
+    }
 
     console.log('Nodes before filter:', nodes.length, 'nodes');
     let filteredNodes = await this.filterNodes(nodes, filters);
@@ -71,7 +86,7 @@ export class MetadataPostFilter implements BaseNodePostprocessor {
     return filteredNodes;
   }
 
-  async generateFilters(query: string): Promise<MetadataFiledFilter[]> {
+  async generateFilters(query: string): Promise<MetadataFieldFilter[]> {
     try {
       const llm = this.serviceContext.llm;
       const prompt = this.metadataFilterChoicePrompt({
@@ -88,7 +103,7 @@ export class MetadataPostFilter implements BaseNodePostprocessor {
     }
   }
 
-  async filterNodes(nodes: NodeWithScore[], filters: MetadataFiledFilter[]) {
+  async filterNodes(nodes: NodeWithScore[], filters: MetadataFieldFilter[]) {
     return nodes.filter(n => {
       const metadata = n.node.metadata;
 
@@ -99,7 +114,7 @@ export class MetadataPostFilter implements BaseNodePostprocessor {
 
       return filters.every(filter => {
         // If the document metadata field is not set, skip the filter.
-        if (!metadata[filter.name]) {
+        if (!metadata[filter.name] || filter.value === '') {
           return true;
         }
         return metadata[filter.name] === filter.value;

--- a/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
+++ b/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
@@ -114,7 +114,7 @@ export class MetadataPostFilter implements BaseNodePostprocessor {
 
       return filters.every(filter => {
         // If the document metadata field is not set, skip the filter.
-        if (!metadata[filter.name] || filter.value === '') {
+        if (!metadata[filter.name] || !filter.value || filter.value === '') {
           return true;
         }
         return metadata[filter.name] === filter.value;

--- a/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
+++ b/src/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter.ts
@@ -1,0 +1,110 @@
+import {BaseNodePostprocessor, NodeWithScore, ServiceContext, serviceContextFromDefaults} from "llamaindex";
+
+export interface MetadataField {
+  name: string;
+  type: string;
+  enums?: string[];
+  default: string;
+  choicePrompt?: string;
+}
+
+export const defaultMetadataFilterChoicePrompt = ({
+  metadataFields,
+  query
+}: {
+  metadataFields: MetadataField[],
+  query: string
+}) => {
+  return `Provide the definition of metadata fields and query, please generate 
+the Filter object array in JSON format, the Filter object has two fields: name, value, optional (boolean).
+
+<Metadata Fields Definition>
+${JSON.stringify(metadataFields, null, 2)}
+
+<Query>
+${query}
+
+<Filters>
+  `;
+}
+
+export interface MetadataFiledFilter {
+  name: string;
+  value: any;
+  optional: boolean;
+}
+
+export type MetadataFilterChoicePrompt = typeof defaultMetadataFilterChoicePrompt;
+
+export type MetadataPostFilterOptions = Partial<MetadataPostFilter>;
+
+export class MetadataPostFilter implements BaseNodePostprocessor {
+  serviceContext: ServiceContext = serviceContextFromDefaults();
+  metadataFilterChoicePrompt: MetadataFilterChoicePrompt = defaultMetadataFilterChoicePrompt;
+
+  /**
+   * The definition of metadata fields.
+   */
+  metadata_fields: MetadataField[] = [];
+
+  constructor(init?: MetadataPostFilterOptions) {
+    Object.assign(this, init);
+  }
+
+  async postprocessNodes(nodes: NodeWithScore[], query: string): Promise<NodeWithScore[]> {
+    const filters = await this.generateFilters(query);
+    console.info('Apply filters:', filters);
+
+    console.log('Nodes before filter:', nodes.length, 'nodes');
+    let filteredNodes = await this.filterNodes(nodes, filters);
+    console.log('Nodes after filter:', filteredNodes.length, 'nodes');
+
+    if (filteredNodes.length === 0) {
+      const requiredFilters = filters.filter(f => !f.optional);
+      console.info('No nodes left after filtering, fallback to filtering with required filters.', {
+        requiredFilters
+      });
+      filteredNodes = await this.filterNodes(nodes, requiredFilters);
+      console.log('Nodes after filtering with required filters:', filteredNodes.length, 'nodes');
+    }
+
+    return filteredNodes;
+  }
+
+  async generateFilters(query: string): Promise<MetadataFiledFilter[]> {
+    try {
+      const llm = this.serviceContext.llm;
+      const prompt = this.metadataFilterChoicePrompt({
+        metadataFields: this.metadata_fields,
+        query
+      });
+      const raw = await llm.complete({
+        prompt
+      });
+      return JSON.parse(raw.text);
+    } catch (e) {
+      console.warn('Failed to generate filters, fallback to using empty filters:', e);
+      return [];
+    }
+  }
+
+  async filterNodes(nodes: NodeWithScore[], filters: MetadataFiledFilter[]) {
+    return nodes.filter(n => {
+      const metadata = n.node.metadata;
+
+      // If the document metadata is not found, skip the filter.
+      if (!metadata) {
+        return true;
+      }
+
+      return filters.every(filter => {
+        // If the document metadata field is not set, skip the filter.
+        if (!metadata[filter.name]) {
+          return true;
+        }
+        return metadata[filter.name] === filter.value;
+      });
+    });
+  }
+
+}


### PR DESCRIPTION
The chatting feature now support automated metadata filter to exclude unnecessary documents.

And the `/indexes/[name]/retrive` API support pass `filters` parameters:

```json
{
    "query": "Does TiDB support FK?",
    "search_top_k": 200,
    "filters": [
        {
            "name": "tidb_version",
            "value": "stable"
        }
    ],
    "top_k": 10
}
```