### PR TITLE
fix: zod validate query must has at least one char

### DIFF
--- a/src/app/api/v1/chats/route.ts
+++ b/src/app/api/v1/chats/route.ts
@@ -13,7 +13,7 @@ import {z} from 'zod';
 
 const ChatRequest = z.object({
   messages: z.object({
-    content: z.string(),
+    content: z.string().min(1),
     role: z.string(),
   }).array(),
   sessionId: z.string().optional(),

--- a/src/core/services/retrieving.ts
+++ b/src/core/services/retrieving.ts
@@ -18,7 +18,7 @@ import type {UUID} from 'node:crypto';
 import z from "zod";
 
 export const retrieveOptionsSchema = z.object({
-  query: z.string(),
+  query: z.string().min(1),
   // TODO: using engine name instead.
   engine: z.number().optional(),
   filters: z.array(metadataFilterSchema).optional(),


### PR DESCRIPTION
Fix internal error if the query is empty.

> The input must not exceed the max input tokens for the model (8192 tokens for text-embedding-ada-002), cannot be an empty string.

Reference: https://platform.openai.com/docs/api-reference/embeddings/create