### PR TITLE
feat: metadata-filter support custom llm

### DIFF
--- a/src/app/api/test/reranker/route.ts
+++ b/src/app/api/test/reranker/route.ts
@@ -76,7 +76,7 @@ export const POST = defineHandler({
   body
 }) => {
   const { query, config, llmConfig, top_k } = body;
-  const llm = llmConfig ? await buildLLM(llmConfig) : undefined;
+  const llm = llmConfig ? buildLLM(llmConfig) : undefined;
   const serviceContext = serviceContextFromDefaults({
     llm: llm
   })

--- a/src/app/api/v1/indexes/[name]/retrieve/route.ts
+++ b/src/app/api/v1/indexes/[name]/retrieve/route.ts
@@ -36,7 +36,7 @@ export const POST = defineHandler({
 
   const flow = await getFlow(baseRegistry);
   const serviceContext = serviceContextFromDefaults({
-    llm: await buildLLM(llmConfig),
+    llm: buildLLM(llmConfig),
     embedModel: await buildEmbedding(index.config.embedding),
   });
 

--- a/src/core/services/llamaindex/chating.ts
+++ b/src/core/services/llamaindex/chating.ts
@@ -135,7 +135,7 @@ export class LlamaindexChatService extends AppChatService {
     });
 
     // Service context.
-    const llm = await buildLLM(llmConfig!, trace);
+    const llm = buildLLM(llmConfig!, trace);
     const promptHelper = new PromptHelper(llm.metadata.contextWindow);
     const embedModel = await buildEmbedding(this.index.config.embedding);
     const serviceContext = serviceContextFromDefaults({

--- a/src/core/services/llamaindex/indexing.ts
+++ b/src/core/services/llamaindex/indexing.ts
@@ -47,7 +47,7 @@ export class LlamaindexIndexProvider extends DocumentIndexProvider {
     });
 
     // Select and config the llm for indexing (metadata extractor).
-    const llm = await buildLLM(index.config.llm);
+    const llm = buildLLM(index.config.llm);
     llm.metadata.model = index.config.llm.options?.model!;
 
     // Select and config the embedding (important and immutable)

--- a/src/lib/llamaindex/builders/indices.ts
+++ b/src/lib/llamaindex/builders/indices.ts
@@ -24,7 +24,7 @@ export async function createVectorStoreIndex (id: number) {
       dimensions: DEFAULT_TIDB_VECTOR_DIMENSIONS,
     }),
     serviceContext: serviceContextFromDefaults({
-      llm: await buildLLM(index.config.llm),
+      llm: buildLLM(index.config.llm),
       embedModel: await buildEmbedding(index.config.embedding),
     }),
   });

--- a/src/lib/llamaindex/builders/llm.ts
+++ b/src/lib/llamaindex/builders/llm.ts
@@ -4,7 +4,7 @@ import {LangfuseTraceClient} from "langfuse";
 import {OpenAI, Ollama} from "llamaindex";
 import {Bitdeer} from "@/lib/llamaindex/llm/bitdeer";
 
-export async function buildLLM ({ provider, options}: LLMConfig, trace?: LangfuseTraceClient) {
+export function buildLLM ({ provider, options}: LLMConfig, trace?: LangfuseTraceClient) {
   let baseLLM;
   switch (provider) {
     case LLMProvider.OPENAI:

--- a/src/lib/llamaindex/builders/metadata-filter.ts
+++ b/src/lib/llamaindex/builders/metadata-filter.ts
@@ -1,17 +1,22 @@
+import {buildLLM} from "@/lib/llamaindex/builders/llm";
 import {MetadataFilterConfig} from "@/lib/llamaindex/config/metadata-filter";
 import {
   MetadataPostFilter
 } from "@/lib/llamaindex/postprocessors/postfilters/MetadataPostFilter";
 import {ServiceContext} from 'llamaindex';
 
-export function buildMetadataFilter (serviceContext: ServiceContext, { provider, options }: MetadataFilterConfig) {
-    switch (provider) {
+export function buildMetadataFilter (serviceContext: ServiceContext, config: MetadataFilterConfig) {
+    switch (config.provider) {
       case 'default':
+        let llm = serviceContext.llm;
+        if (config.options?.llm) {
+          llm = buildLLM(config.options.llm);
+        }
         return new MetadataPostFilter({
-          ...options,
-          serviceContext,
+          llm,
+
         });
       default:
-        throw new Error(`Unknown metadata filter provider: ${provider}`)
+        throw new Error(`Unknown metadata filter provider: ${config.provider}`)
     }
 }

--- a/src/lib/llamaindex/config/metadata-filter.ts
+++ b/src/lib/llamaindex/config/metadata-filter.ts
@@ -26,7 +26,7 @@ export enum MetadataFilterProvider {
 }
 
 export const DefaultMetadataFilterOptions = z.object({
-  llm: LLMConfigSchema,
+  llm: LLMConfigSchema.optional(),
   metadata_fields: z.array(metadataFieldSchema).optional(),
   filters: z.array(metadataFilterSchema).optional()
 });

--- a/src/lib/llamaindex/config/metadata-filter.ts
+++ b/src/lib/llamaindex/config/metadata-filter.ts
@@ -1,3 +1,4 @@
+import {LLMConfigSchema} from "@/lib/llamaindex/config/llm";
 import {z} from "zod";
 
 export const metadataFilterSchema = z.object({
@@ -25,6 +26,7 @@ export enum MetadataFilterProvider {
 }
 
 export const DefaultMetadataFilterOptions = z.object({
+  llm: LLMConfigSchema,
   metadata_fields: z.array(metadataFieldSchema).optional(),
   filters: z.array(metadataFilterSchema).optional()
 });


### PR DESCRIPTION
Allows config independent LLM model (such as faster and cheaper `gpt-3.5-turbo` model) for metadata-filters instead of using the llm in the `serviceContext`, which can speed up this process.