### PR TITLE
feat: support stream and chat_engine options for chats api

### DIFF
--- a/src/app/api/v1/chat_engines/[id]/route.ts
+++ b/src/app/api/v1/chat_engines/[id]/route.ts
@@ -1,7 +1,7 @@
 import {CreateChatEngineOptionsSchema} from "@/core/schema/chat_engines";
 import {
   deleteChatEngine,
-  getChatEngine,
+  getChatEngineById,
   updateChatEngine
 } from '@/core/repositories/chat_engine';
 import { defineHandler } from '@/lib/next/handler';
@@ -18,7 +18,7 @@ export const GET = defineHandler({
 }, async ({
   params,
 }) => {
-  const engine = await getChatEngine(params.id);
+  const engine = await getChatEngineById(params.id);
   if (!engine) {
     notFound();
   }

--- a/src/core/db/schema.d.ts
+++ b/src/core/db/schema.d.ts
@@ -39,6 +39,7 @@ export interface Chat {
   deleted_by: string | null;
   engine: string;
   engine_id: number | null;
+  engine_name: string | null;
   engine_options: Json;
   id: Generated<number>;
   title: string;

--- a/src/core/services/retrieving.ts
+++ b/src/core/services/retrieving.ts
@@ -21,8 +21,10 @@ import z from "zod";
 
 export const retrieveOptionsSchema = z.object({
   query: z.string().min(1),
-  // TODO: using engine name instead.
+  // TODO: using chat engine name instead.
+  // @Deprecated
   engine: z.number().optional(),
+  chat_engine: z.string().optional(),
   filters: z.array(metadataFilterSchema).optional(),
   search_top_k: z.number().int().optional(),
   top_k:  z.number().int().optional(),
@@ -106,7 +108,7 @@ export abstract class AppRetrieveService extends AppIndexBaseService {
       callbacks?.onRetrieved(retrieve.id, results);
 
       if (options.reversed) {
-        // use cloned array to avoid affecting langfuse output tracing.
+        // use a cloned array to avoid affecting langfuse output tracing.
         return Array.from(results).reverse();
       } else {
         return results;


### PR DESCRIPTION
#### For example

```bash
curl --location 'http://127.0.0.1:3000/api/v1/chats' \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer xxxxxx' \
  --data '{
      "messages": [
          {
              "role": "user",
              "content": "what is tidb?"
          }
      ],
      "index": "default",
      "chat_engine": "jira-bot",
      "stream": false
  }'
```