### PR TITLE
ci: support automatic metadata for docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "The tag to build the image with (format *.*.*)"
+        description: "The tag to build the image with. Format *.*.*((beta|rc)*)?"
         required: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,35 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "The tag to build the image with"
+        description: "The tag to build the image with (format *.*.*)"
         required: true
 
 jobs:
+    docker-metadata:
+      name: Generate docker metadata
+      runs-on: ubuntu-latest
+      outputs:
+        tags: ${{steps.meta.outputs.tags}}
+        labels: ${{steps.meta.outputs.labels}}
+        annotations: ${{steps.meta.outputs.annotations}}
+      permissions:
+        contents: read
+      steps:
+        - name: Docker metadata
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            github-token: ${{ github.token }}
+            images: "{0}/{1}"
+            tags: |
+              type=pep440,value=${{inputs.tag || github.ref_name}},pattern={{version}}
+              type=pep440,value=${{inputs.tag || github.ref_name}},pattern={{major}}.{{minor}}
+              type=pep440,value=${{inputs.tag || github.ref_name}},pattern={{major}}
+
     build-backend:
       name: Build and Push Backend Image
       runs-on: ubuntu-latest
+      needs: docker-metadata
       permissions:
         contents: read
         packages: write
@@ -39,12 +61,14 @@ jobs:
             context: backend
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: |
-                ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}/backend:${{ inputs.tag || github.ref_name }}
+            tags: ${{format(needs.docker-metadata.outputs.tags, secrets.RELEASE_DOCKERHUB_USERNAME, 'backend')}}
+            labels: ${{needs.docker-metadata.outputs.labels}}
+            annotations: ${{needs.docker-metadata.outputs.annotations}}
 
     build-frontend:
       name: Build and Push Frontend Image
       runs-on: ubuntu-latest
+      needs: docker-metadata
       permissions:
         contents: read
         packages: write
@@ -71,5 +95,6 @@ jobs:
             file: ./frontend/Dockerfile
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: |
-                ${{ secrets.RELEASE_DOCKERHUB_USERNAME }}/frontend:${{ inputs.tag || github.ref_name }}
+            tags: ${{format(needs.docker-metadata.outputs.tags, secrets.RELEASE_DOCKERHUB_USERNAME, 'frontend')}}
+            labels: ${{needs.docker-metadata.outputs.labels}}
+            annotations: ${{needs.docker-metadata.outputs.annotations}}


### PR DESCRIPTION
Test this github action using [act](https://nektosact.com/introduction.html):
```bash
act workflow_dispatch --container-architecture linux/amd64 -j 'docker-metadata' --input tag=<VERSION> -s GITHUB_TOKEN=<YOUR_GITHUB_TOKEN>
```

See [version rules](https://github.com/docker/metadata-action?tab=readme-ov-file#typepep440):
- `1.2.3` => [`1`, `1.2`, `1.2.3`]
- `1.2.3beta0` => [`1.2.3b0`]

[Run with 0.1.4beta0](https://github.com/pingcap/tidb.ai/actions/runs/10381936533)

Images:
- [tidbai/backend:0.1.4b0](https://hub.docker.com/layers/tidbai/backend/0.1.4b0/images/sha256-3bcfddcecd91d95eaaae868b2bc9d453d629bc2087a8f7290a3ac703822bad42)
- [tidbai/frontend:0.1.4b0](https://hub.docker.com/layers/tidbai/frontend/0.1.4b0/images/sha256-b0ebf395ec590ce33155cc925a23bd839c969d210f8115f3d7bcc9c85baee78c?context=explore)

