### PR TITLE
feat: upgrade fastapi to 0.115 and refine document filters

### DIFF
--- a/backend/app/api/admin_routes/document.py
+++ b/backend/app/api/admin_routes/document.py
@@ -1,52 +1,25 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Query
 from fastapi_pagination import Params, Page
 
 from app.api.deps import SessionDep, CurrentSuperuserDep
 from app.repositories import document_repo
-from app.models import Document, DocIndexTaskStatus
+from app.models import Document
 
-from datetime import datetime
-
-from app.types import MimeTypes
+from app.repositories.document import DocumentFilters
 
 router = APIRouter()
-
 
 @router.get("/admin/documents")
 def list_documents(
     session: SessionDep,
     user: CurrentSuperuserDep,
+    filters: Annotated[DocumentFilters, Query()],
     params: Params = Depends(),
-    source_uri: str | None = Query(
-        None,
-        description="[Fuzzy Match] source URI field, will search for the source URI that contains the given string."
-    ),
-    data_source_id: int | None = None,
-    created_at_start: datetime | None = None,
-    created_at_end: datetime | None = None,
-    updated_at_start: datetime | None = None,
-    updated_at_end: datetime | None = None,
-    last_modified_at_start: datetime | None = None,
-    last_modified_at_end: datetime | None = None,
-    name: str | None = Query(
-        None,
-        description="[Fuzzy Match] name field, will search for the name that contains the given string."
-    ),
-    mime_type: MimeTypes | None = None,
-    index_status: DocIndexTaskStatus | None = None,
 ) -> Page[Document]:
     return document_repo.paginate(
         session=session,
+        filters=filters,
         params=params,
-        source_uri=source_uri,
-        data_source_id=data_source_id,
-        created_at_start=created_at_start,
-        created_at_end=created_at_end,
-        updated_at_start=updated_at_start,
-        updated_at_end=updated_at_end,
-        last_modified_at_start=last_modified_at_start,
-        last_modified_at_end=last_modified_at_end,
-        name=name,
-        mime_type=mime_type,
-        index_status=index_status,
     )

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import datetime
 
 from llama_index.core.schema import Document as LlamaDocument
+from pydantic import ConfigDict
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlmodel import (
     Field,
@@ -26,6 +27,9 @@ class DocIndexTaskStatus(str, enum.Enum):
 
 
 class Document(UpdatableBaseModel, table=True):
+    # Avoid "expected `enum` but got `str`" error.
+    model_config = ConfigDict(use_enum_values=True)
+
     id: Optional[int] = Field(default=None, primary_key=True)
     hash: str = Field(max_length=32)
     name: str = Field(max_length=256)

--- a/backend/app/repositories/document.py
+++ b/backend/app/repositories/document.py
@@ -1,7 +1,7 @@
-from typing import Optional, cast
+from typing import Optional
 
-from sqlalchemy import String
-from sqlmodel import select, Session, col, func
+from pydantic import Field, BaseModel
+from sqlmodel import select, Session, col
 from fastapi_pagination import Params, Page
 from fastapi_pagination.ext.sqlmodel import paginate
 
@@ -13,49 +13,59 @@ from datetime import datetime
 from app.types import MimeTypes
 
 
+class DocumentFilters(BaseModel):
+    name: Optional[str] = Field(
+        None,
+        description="[Fuzzy Match] name field, will search for the name that contains the given string."
+    )
+    source_uri: Optional[str] = Field(
+        None,
+        description="[Fuzzy Match] source URI field, will search for the source URI that contains the given string."
+    )
+    data_source_id: Optional[int]  = Field(None)
+    created_at_start: Optional[datetime] = Field(None)
+    created_at_end: Optional[datetime] = None
+    updated_at_start: Optional[datetime] = None
+    updated_at_end: Optional[datetime] = None
+    last_modified_at_start: Optional[datetime] = None
+    last_modified_at_end: Optional[datetime] = None
+    mime_type: Optional[MimeTypes | None] = None
+    index_status: Optional[DocIndexTaskStatus | None] = None
+
+
 class DocumentRepo(BaseRepo):
     model_cls = Document
 
     def paginate(
         self,
         session: Session,
-        params: Params | None = Params(),
-        source_uri: Optional[str] = None,
-        data_source_id: Optional[int] = None,
-        created_at_start: Optional[datetime] = None,
-        created_at_end: Optional[datetime] = None,
-        updated_at_start: Optional[datetime] = None,
-        updated_at_end: Optional[datetime] = None,
-        last_modified_at_start: Optional[datetime] = None,
-        last_modified_at_end: Optional[datetime] = None,
-        name: Optional[str] = None,
-        mime_type: Optional[MimeTypes] = None,
-        index_status: Optional[DocIndexTaskStatus] = None,
+        filters: DocumentFilters,
+        params: Params | None = Params()
     ) -> Page[Document]:
         # build the select statement via conditions
         stmt = select(Document)
-        if source_uri:
-            stmt = stmt.where(col(Document.source_uri).contains(source_uri))
-        if data_source_id:
-            stmt = stmt.where(Document.data_source_id == data_source_id)
-        if created_at_start:
-            stmt = stmt.where(Document.created_at >= created_at_start)
-        if created_at_end:
-            stmt = stmt.where(Document.created_at <= created_at_end)
-        if updated_at_start:
-            stmt = stmt.where(Document.updated_at >= updated_at_start)
-        if updated_at_end:
-            stmt = stmt.where(Document.updated_at <= updated_at_end)
-        if last_modified_at_start:
-            stmt = stmt.where(Document.last_modified_at >= last_modified_at_start)
-        if last_modified_at_end:
-            stmt = stmt.where(Document.last_modified_at <= last_modified_at_end)
-        if name:
-            stmt = stmt.where(col(Document.name).contains(name))
-        if mime_type:
-            stmt = stmt.where(Document.mime_type == mime_type)
-        if index_status:
-            stmt = stmt.where(Document.index_status == index_status)
+        if filters.source_uri:
+            stmt = stmt.where(col(Document.source_uri).contains(filters.source_uri))
+        if filters.data_source_id:
+            stmt = stmt.where(Document.data_source_id == filters.data_source_id)
+        if filters.created_at_start:
+            stmt = stmt.where(Document.created_at >= filters.created_at_start)
+        if filters.created_at_end:
+            stmt = stmt.where(Document.created_at <= filters.created_at_end)
+        if filters.updated_at_start:
+            stmt = stmt.where(Document.updated_at >= filters.updated_at_start)
+        if filters.updated_at_end:
+            stmt = stmt.where(Document.updated_at <= filters.updated_at_end)
+        if filters.last_modified_at_start:
+            stmt = stmt.where(Document.last_modified_at >= filters.last_modified_at_start)
+        if filters.last_modified_at_end:
+            stmt = stmt.where(Document.last_modified_at <= filters.last_modified_at_end)
+        if filters.name:
+            stmt = stmt.where(col(Document.name).contains(filters.name))
+        if filters.mime_type:
+            stmt = stmt.where(Document.mime_type == filters.mime_type)
+        if filters.index_status:
+            stmt = stmt.where(Document.index_status == filters.index_status)
 
         # Make sure the newer edited record is always on top
         stmt = stmt.order_by(Document.updated_at.desc())

--- a/backend/app/repositories/document.py
+++ b/backend/app/repositories/document.py
@@ -29,8 +29,8 @@ class DocumentFilters(BaseModel):
     updated_at_end: Optional[datetime] = None
     last_modified_at_start: Optional[datetime] = None
     last_modified_at_end: Optional[datetime] = None
-    mime_type: Optional[MimeTypes | None] = None
-    index_status: Optional[DocIndexTaskStatus | None] = None
+    mime_type: Optional[MimeTypes] = None
+    index_status: Optional[DocIndexTaskStatus] = None
 
 
 class DocumentRepo(BaseRepo):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "wd0517", email = "me@wangdi.ink" }
 ]
 dependencies = [
-    "fastapi>=0.111.1",
+    "fastapi>=0.115.4",
     "sqlmodel==0.0.19",
     "pymysql>=1.1.1",
     "celery>=5.4.0",
@@ -53,6 +53,7 @@ dependencies = [
     "python-pptx>=1.0.2",
     "colorama>=0.4.6",
     "openpyxl>=3.1.5",
+    "fastapi-cli>=0.0.5",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -130,16 +130,14 @@ docx2txt==0.8
     # via deepeval
 dspy-ai==2.4.9
 email-validator==2.1.1
-    # via fastapi
     # via fastapi-users
 et-xmlfile==1.1.0
     # via openpyxl
 execnet==2.1.1
     # via pytest-xdist
-fastapi==0.111.1
+fastapi==0.115.4
     # via fastapi-users
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi-cli==0.0.5
 fastapi-pagination==0.12.25
 fastapi-users==13.0.0
     # via fastapi-users-db-sqlmodel
@@ -232,12 +230,11 @@ httpcore==1.0.5
 httplib2==0.22.0
     # via google-api-python-client
     # via google-auth-httplib2
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
 httpx==0.27.0
     # via anthropic
     # via cohere
-    # via fastapi
     # via httpx-oauth
     # via langfuse
     # via llama-cloud
@@ -267,7 +264,6 @@ importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
-    # via fastapi
 jiter==0.5.0
     # via anthropic
     # via openai
@@ -573,7 +569,6 @@ python-dotenv==1.0.1
     # via pydantic-settings
     # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
     # via fastapi-users
 python-pptx==1.0.2
 pytz==2024.1
@@ -651,7 +646,7 @@ sqlalchemy==2.0.30
     # via sqlmodel
 sqlmodel==0.0.19
     # via fastapi-users-db-sqlmodel
-starlette==0.37.2
+starlette==0.41.2
     # via fastapi
 striprtf==0.0.26
     # via llama-index-readers-file
@@ -733,18 +728,18 @@ urllib3==2.2.1
     # via sentry-sdk
     # via types-requests
 uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
+    # via fastapi-cli
+uvloop==0.21.0 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
     # via uvicorn
 vine==5.1.0
     # via amqp
     # via celery
     # via kombu
-watchfiles==0.22.0
+watchfiles==0.24.0
     # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
+websockets==14.0
     # via uvicorn
 wrapt==1.16.0
     # via deprecated

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -130,16 +130,14 @@ docx2txt==0.8
     # via deepeval
 dspy-ai==2.4.9
 email-validator==2.1.1
-    # via fastapi
     # via fastapi-users
 et-xmlfile==1.1.0
     # via openpyxl
 execnet==2.1.1
     # via pytest-xdist
-fastapi==0.111.1
+fastapi==0.115.4
     # via fastapi-users
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi-cli==0.0.5
 fastapi-pagination==0.12.25
 fastapi-users==13.0.0
     # via fastapi-users-db-sqlmodel
@@ -232,12 +230,11 @@ httpcore==1.0.5
 httplib2==0.22.0
     # via google-api-python-client
     # via google-auth-httplib2
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
 httpx==0.27.0
     # via anthropic
     # via cohere
-    # via fastapi
     # via httpx-oauth
     # via langfuse
     # via llama-cloud
@@ -267,7 +264,6 @@ importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
-    # via fastapi
 jiter==0.5.0
     # via anthropic
     # via openai
@@ -573,7 +569,6 @@ python-dotenv==1.0.1
     # via pydantic-settings
     # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
     # via fastapi-users
 python-pptx==1.0.2
 pytz==2024.1
@@ -651,7 +646,7 @@ sqlalchemy==2.0.30
     # via sqlmodel
 sqlmodel==0.0.19
     # via fastapi-users-db-sqlmodel
-starlette==0.37.2
+starlette==0.41.2
     # via fastapi
 striprtf==0.0.26
     # via llama-index-readers-file
@@ -733,18 +728,18 @@ urllib3==2.2.1
     # via sentry-sdk
     # via types-requests
 uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
+    # via fastapi-cli
+uvloop==0.21.0 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
     # via uvicorn
 vine==5.1.0
     # via amqp
     # via celery
     # via kombu
-watchfiles==0.22.0
+watchfiles==0.24.0
     # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
+websockets==14.0
     # via uvicorn
 wrapt==1.16.0
     # via deprecated


### PR DESCRIPTION
Since [fastapi 0.115.x](https://github.com/fastapi/fastapi/releases/tag/0.115.0), fastapi support declare`Query`,`Header`, and `Cookie` parameters with Pydantic models. Now we can wrap mutiple filters into a model in a nice way.